### PR TITLE
Fix for non-MongoError check.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -13,7 +13,7 @@ function ProcessMongoDBErrors(schema) {
 
 function mongodbErrorHandler (err, doc, next) {
     if (err.name !== 'MongoError') {
-        next(error);
+        return next(err);
     }
 
     var path = err.message.match(/\$([\w]*)_\d/)[1];


### PR DESCRIPTION
If you have non-Mongo Error, ie Validator error, you will get:
```
node_modules/mongoose-mongodb-errors/lib/plugin.js:13
        next(error);
             ^
ReferenceError: error is not defined
```