### PR TITLE
Fix for #5

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -16,8 +16,8 @@ function mongodbErrorHandler (err, doc, next) {
         return next(err);
     }
 
-    var path = err.message.match(/\$([\w]*)_\d/)[1];
-    var value = err.message.match(/\{\s:\s\"?([^\"\s]+)/)[1];
+    var path = err.message.replace(/^.+index: (.+)_\d+ dup key.+$/, '$1');
+    var value = err.message.replace(/^.+ dup key: \{\s:\s\"?([^\"\s]+).+$/, '$1');;
 
     var validationError = new mongoose.Error.ValidationError();
     validationError.errors[path] = validationError.errors[path] || {};


### PR DESCRIPTION
Fix #5 
Change regexp to use replace instead of match so in the worst case both "path" and "value" will be all error message.
Also removed __$__ from regexp.
new regular expression based on [current mongo code](https://github.com/mongodb/mongo/blob/07bfb1286cb6d01d8080ab3b39a1c76dd123e002/src/mongo/db/storage/wiredtiger/wiredtiger_index.cpp#L123)